### PR TITLE
Fix issue connecting to Hive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN useradd -U -m superset && \
         libldap2-dev \
         libpq-dev \
         libsasl2-dev \
+	libsasl2-2 \
+	libsasl2-modules-gssapi-mit \
         libssl1.0 && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/* && \


### PR DESCRIPTION
I've had the issue that I haven't been able to connect to Hive from this image, similar to #103.
Adding the packages `libsasl2-2` `libsasl2-modules-gssapi-mit` to the `apt-get install` resolved that for me.
I can now successfully connect to Hive with the authentication mechanism `NONE`.

Would that change be suitable to merge?