### PR TITLE
Install latest Superset from source

### DIFF
--- a/database-dependencies.txt
+++ b/database-dependencies.txt
@@ -1,0 +1,33 @@
+#
+# This file is created for superset database dependencies plugins
+#
+mysqlclient==1.3.13	                # MySQL         mysql://
+cx_Oracle==7.0.0	                # Oracle        oracle://
+snowflake-sqlalchemy==1.1.6	        # Snowflake     snowflake://
+sqlalchemy-redshift==0.7.2	        # Redshift      redshift+psycopg2://
+pymssql==2.1.4	                    # MSSQL	        mssql://
+impyla==0.14.1	                    # Impala	    impala://
+PyAthenaJDBC==2.0.1	                # Athena	    awsathena+jdbc://
+PyAthena==1.4.4	                    # Athena	    awsathena+rest://
+sqlalchemy-vertica-python==0.4.3	# Vertica	    vertica+vertica_python://
+sqlalchemy-clickhouse==0.1.5.post0	# ClickHouse    clickhouse://
+kylinpy==2.1.2	                    # Kylin	        kylin://
+pybigquery==0.4.8	                # BigQuery	    bigquery://
+sqlalchemy-teradata==0.9.0.dev0	    # Teradata	    teradata://
+psycopg2==2.7.6.1	                # Postgres, Greenplum       postgresql+psycopg2://
+PyHive==0.6.1	                    # Presto  presto://, Hive    hive://, SparkSQL    jdbc+hive://
+pinotdb==0.2.3                      # PintoDB
+
+#
+# Optional packages
+#
+flower==0.9.2
+tornado==5.1.1            # via flower
+thrift-sasl==0.3.0
+thrift==0.11.0
+sasl==0.2.1               # via thrift-sasl
+boto3==1.4.7
+botocore==1.7.48
+docutils==0.14            # via botocore
+jmespath==0.9.3           # via boto3, botocore
+s3transfer==0.1.13        # via boto3


### PR DESCRIPTION
Retooling docker file to build superset from source. This docker has beed tested with `0.33.0rc1` version of superset.

# Steps for Validating and Testing new Docker
(For the benefit of those who might want to follow)

## Build new image
Note - I have already built this and published to dockerhub. Use can use image form [here](https://hub.docker.com/r/pavanpaik/docker-superset) for testing.
```
git clone https://github.com/pavanpaik/docker-superset.git
cd docker-superset/
docker build -t pavanpaik/docker-superset:0.33.0rc1 --build-arg SUPERSET_VERSION=0.33.0rc1 -f ./Dockerfile .
```

## Start Superset locally
note - Update `examples/sqllite/docker-compose.yml` superset image with the docker tag to use for testing
```
cd examples/sqllite
docker-compose up -d redis
docker-compose up -d superset
```

## Initialize Superset userid and load examples
```
docker exec -it sqlite_superset_1 bash
fabmanager create-admin --app superset --username admin --firstname apache --lastname superset --email apache-superset@fab.com --password admin
superset db upgrade
superset init
superset load_example
```

Now you can access superset on the browser at - http://localhost:8088/