### PR TITLE
adjust number of gunicorn workers and threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,14 +42,15 @@ ENV GUNICORN_BIND=0.0.0.0:8088 \
     GUNICORN_LIMIT_REQUEST_FIELD_SIZE=0 \
     GUNICORN_LIMIT_REQUEST_LINE=0 \
     GUNICORN_TIMEOUT=60 \
-    GUNICORN_WORKERS=2 \
+    GUNICORN_WORKERS=3 \
+    GUNICORN_THREADS=4 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     PYTHONPATH=/etc/superset:/home/superset:$PYTHONPATH \
     SUPERSET_REPO=apache/incubator-superset \
     SUPERSET_VERSION=${SUPERSET_VERSION} \
     SUPERSET_HOME=/var/lib/superset
-ENV GUNICORN_CMD_ARGS="--workers ${GUNICORN_WORKERS} --timeout ${GUNICORN_TIMEOUT} --bind ${GUNICORN_BIND} --limit-request-line ${GUNICORN_LIMIT_REQUEST_LINE} --limit-request-field_size ${GUNICORN_LIMIT_REQUEST_FIELD_SIZE}"
+ENV GUNICORN_CMD_ARGS="--workers ${GUNICORN_WORKERS} --threads ${GUNICORN_THREADS} --timeout ${GUNICORN_TIMEOUT} --bind ${GUNICORN_BIND} --limit-request-line ${GUNICORN_LIMIT_REQUEST_LINE} --limit-request-field_size ${GUNICORN_LIMIT_REQUEST_FIELD_SIZE}"
 
 # Create superset user & install dependencies
 WORKDIR /tmp/superset


### PR DESCRIPTION
at the current configuration only two requests can be handled in parallel. with this change we increase the number of workers from 2 to 3 which follows the rule of thumb for a single core instance (`nb_workers = 2*nb_cores + 1`). That is a rather conservative setting but makes sure the docker image works well on a small machine. The change also introduces 4 threads per worker to allow 12 concurrent requests in total. The usage of threads makes sense as typical requests in superset are rather io-bound (waiting for sql queries to finish) rather than cpu-bound.

I ran into this issue as dashboards with lots of graphs generated  a lot of concurrent requests. That is why they piled up and the health check was not responsive anymore and the instance was removed from the load balancer.

see
 - #140 
 - https://stackoverflow.com/a/41696500/1245622
 - http://docs.gunicorn.org/en/stable/settings.html#worker-processes
