### PR TITLE
Add Snowflake connector for SQLAlchemy

### DIFF
--- a/requirements-db.txt
+++ b/requirements-db.txt
@@ -14,6 +14,6 @@ pyhive==0.5.1
 pyldap==2.4.28
 pymssql==2.1.4
 redis==3.2.1
+snowflake-sqlalchemy==1.1.16
 sqlalchemy-clickhouse==0.1.5.post0
 sqlalchemy-redshift==0.7.1
-snowflake-sqlalchemy==1.1.16

--- a/requirements-db.txt
+++ b/requirements-db.txt
@@ -16,3 +16,4 @@ pymssql==2.1.4
 redis==3.2.1
 sqlalchemy-clickhouse==0.1.5.post0
 sqlalchemy-redshift==0.7.1
+snowflake-sqlalchemy==1.1.16


### PR DESCRIPTION
Add snowflake-sqlalchemy to requirements-db.txt to support connections to snowflake databases. Works in latest and 0.35.1 branches.