### PR TITLE
Update elasticsearch-dbapi version to 0.1.1

### DIFF
--- a/requirements-db.txt
+++ b/requirements-db.txt
@@ -1,5 +1,5 @@
 cx_oracle==7.3.0
-elasticsearch-dbapi==0.1.0
+elasticsearch-dbapi==0.1.1
 flask-cors==3.0.3
 flask-mail==0.9.1
 flask-oauth==0.12


### PR DESCRIPTION
Hello,

Related to https://github.com/preset-io/elasticsearch-dbapi/issues/13.
Elasticsearch-DBApi have an issue about Elasticsearch SQL Lab commit with a readonly exception.

This issue have been fixed in the latest version. Need to upgrade the Docker Superset requirements.

Regards