### PR TITLE
Updates RedisCache imports from werkzeug to cachelib

### DIFF
--- a/examples/celery/superset/superset_config.py
+++ b/examples/celery/superset/superset_config.py
@@ -1,6 +1,6 @@
 import os
 
-from werkzeug.contrib.cache import RedisCache
+from cachelib import RedisCache
 
 
 MAPBOX_API_KEY = os.getenv('MAPBOX_API_KEY', '')


### PR DESCRIPTION
RedisCache has been dropped from `werkzeug` since v1. Caching utilities have now been moved to the `cachelib` package.