### PR TITLE
Fixes celery connection error per #179 and #192

### DIFF
--- a/examples/celery/docker-compose.yml
+++ b/examples/celery/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       MAPBOX_API_KEY: ${MAPBOX_API_KEY}
     volumes:
       - ./superset:/etc/superset
-    command: celery worker
+    command: "celery worker --app=superset.tasks.celery_app:app"
 volumes:
   postgres:
   redis:


### PR DESCRIPTION
Use quotes and specifying the app fixes the connection error returned by the celery example.