### PR TITLE
adding fbprophet to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 authlib==0.14.3
 cx_oracle==7.3.0
 elasticsearch-dbapi==0.1.2
+fbprophet==0.7.1
 flask-cors==3.0.3
 flask-mail==0.9.1
 flask-oauth==0.12


### PR DESCRIPTION
facebook probhet enables new timeseries chart vis type. See https://github.com/apache/incubator-superset/pull/10324