### PR TITLE
override the default health check in demo celery

### DIFF
--- a/examples/celery/docker-compose.yml
+++ b/examples/celery/docker-compose.yml
@@ -37,6 +37,11 @@ services:
     volumes:
       - ./superset:/etc/superset
     command: "celery worker --app=superset.tasks.celery_app:app"
+    healthcheck:
+      test: curl -f http://superset:8088/health || exit 1
+      interval: 1m
+      timeout: 10s
+      retries: 3    
 volumes:
   postgres:
   redis:


### PR DESCRIPTION
```
docker-compose exec worker curl -f http://localhost:8088/health
curl: (7) Failed to connect to localhost port 8088: Connection refused
```

the health check in docker 

`HEALTHCHECK CMD ["curl", "-f", "http://localhost:8088/health"]`

so the problem is in worker, localhost is wrong

something like. 

`curl -f http://superset:8088/health` 

sould work.

I think add a env var `HEALTH_CHECK_HOST` should solve the problem. 

I am using superset docker image 0.38.0

https://github.com/amancevice/docker-superset/issues/51

PS: I found that I could override the health check directly in docker-compose.yml, hence this pull request.