### PR TITLE
Bump Superset version to 1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN groupadd supergroup && \
         libssl-dev && \
     apt-get clean && \
     tar xzf superset.tar.gz && \
-    pip install Cython==0.29.21 && \
+    pip install Cython==0.29.21 pystan==2.19.1.1 && \
     pip install dist/*.tar.gz -r requirements.txt && \
     rm -rf ./*
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REPO             := amancevice/superset
 STAGES           := build dist final
 NODE_VERSION     := 12
 PYTHON_VERSION   := 3.8
-SUPERSET_VERSION := 1.0.1
+SUPERSET_VERSION := 1.1.0
 
 .PHONY: default clean clobber edge latest push
 


### PR DESCRIPTION
Hello 👋 

This PR just upgrades Superset to the latest version, [v1.1.0](https://github.com/apache/superset/releases/tag/1.1.0).