### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ snowflake-sqlalchemy==1.2.1
 sqlalchemy-redshift==0.7.1
 sqlalchemy-trino==0.3.0
 thrift-sasl==0.3.0
+markupsafe==2.0.1


### PR DESCRIPTION
Add `markupsafe` into `requirements.txt`.
Also in https://github.com/apache/superset/blob/master/requirements/base.txt , we can get the `markupsafe` version
fix #229